### PR TITLE
move jsdoc-to-markdown to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -155,6 +155,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.0.1.tgz",
       "integrity": "sha512-G3Aona26cXv8nWIwID6MP11WSishqnyOPQjYaVJ7CfY2Xgu5sHOXM39nQg6XtyfF9++oLV6l2uFGojBb4zglGA==",
+      "dev": true,
       "requires": {
         "array-back": "^2.0.0"
       }
@@ -199,6 +200,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/argv-tools/-/argv-tools-0.1.1.tgz",
       "integrity": "sha512-Cc0dBvx4dvrjjKpyDA6w8RlNAw8Su30NvZbWl/Tv9ZALEVlLVkWQiHMi84Q0xNfpVuSaiQbYkdmWK8g1PLGhKw==",
+      "dev": true,
       "requires": {
         "array-back": "^2.0.0",
         "find-replace": "^2.0.1"
@@ -226,6 +228,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
       "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+      "dev": true,
       "requires": {
         "typical": "^2.6.1"
       }
@@ -252,6 +255,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
       "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+      "dev": true,
       "requires": {
         "lodash": "^4.17.11"
       }
@@ -285,12 +289,14 @@
     "babylon": {
       "version": "7.0.0-beta.19",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
-      "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A=="
+      "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -350,12 +356,14 @@
     "bluebird": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -427,6 +435,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-0.4.1.tgz",
       "integrity": "sha512-4TgWfe9SF+bUy5cCql8gWHqKNrviufNwSYxLjf2utB0pY4+bdcuFwMmY1hDB+67Gz/L1vmhFNhePAjJTFBtV+Q==",
+      "dev": true,
       "requires": {
         "array-back": "^2.0.0",
         "fs-then-native": "^2.0.0",
@@ -449,6 +458,7 @@
       "version": "0.8.9",
       "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
       "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
+      "dev": true,
       "requires": {
         "underscore-contrib": "~0.3.0"
       }
@@ -571,6 +581,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
       "integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
+      "dev": true,
       "requires": {
         "stream-connect": "^1.0.2",
         "stream-via": "^1.0.4"
@@ -620,6 +631,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.0.2.tgz",
       "integrity": "sha512-/qPcbL8zpqg53x4rAaqMFlRV4opN3pbla7I7k9x8kyOBMQoGT6WltjN6sXZuxOXw6DgdK7Ad+ijYS5gjcr7vlA==",
+      "dev": true,
       "requires": {
         "argv-tools": "^0.1.1",
         "array-back": "^2.0.0",
@@ -632,6 +644,7 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.8.0.tgz",
       "integrity": "sha512-Xw18HVx/QzQV3Sc5k1vy3kgtOeGmsKIqwtFFoyjI4bbcpSgnw2CWVULvtakyw4s6fhyAdI6soQQhXc2OzJy62g==",
+      "dev": true,
       "requires": {
         "ansi-escape-sequences": "^4.0.0",
         "array-back": "^2.0.0",
@@ -644,6 +657,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
       "integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
+      "dev": true,
       "requires": {
         "ansi-escape-sequences": "^4.0.0",
         "array-back": "^2.0.0",
@@ -651,10 +665,18 @@
         "typical": "^2.6.1"
       }
     },
+    "commander": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+      "dev": true,
+      "optional": true
+    },
     "common-sequence": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-1.0.2.tgz",
-      "integrity": "sha1-MOB/P49vf5s97oVPILLTnu4Ibeg="
+      "integrity": "sha1-MOB/P49vf5s97oVPILLTnu4Ibeg=",
+      "dev": true
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -665,12 +687,14 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "config-master": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/config-master/-/config-master-3.1.0.tgz",
       "integrity": "sha1-ZnZjWQUFooO/JqSE1oSJ10xUhdo=",
+      "dev": true,
       "requires": {
         "walk-back": "^2.0.1"
       },
@@ -678,7 +702,8 @@
         "walk-back": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz",
-          "integrity": "sha1-VU4qnYdPrEeoywBr9EwvDEmYoKQ="
+          "integrity": "sha1-VU4qnYdPrEeoywBr9EwvDEmYoKQ=",
+          "dev": true
         }
       }
     },
@@ -774,7 +799,8 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -871,6 +897,7 @@
       "version": "3.0.13",
       "resolved": "https://registry.npmjs.org/dmd/-/dmd-3.0.13.tgz",
       "integrity": "sha512-FV/417bH2c/CYpe8BjFEAHoaHaItcJnPlKELi/qyPZdmUom8joyuC78OhhfPUdyKD/WcouTQ2LxQT4M/RoiJ3w==",
+      "dev": true,
       "requires": {
         "array-back": "^2.0.0",
         "cache-point": "^0.4.1",
@@ -965,7 +992,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "eslint": {
       "version": "5.14.1",
@@ -1546,24 +1574,10 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/file-set/-/file-set-2.0.1.tgz",
       "integrity": "sha512-XgOUUpgR6FbbfYcniLw0qm1Am7PnNYIAkd+eXxRt42LiYhjaso0WiuQ+VmrNdtwotyM+cLCfZ56AZrySP3QnKA==",
+      "dev": true,
       "requires": {
         "array-back": "^2.0.0",
         "glob": "^7.1.3"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
       }
     },
     "fill-range": {
@@ -1593,6 +1607,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-2.0.1.tgz",
       "integrity": "sha512-LzDo3Fpa30FLIBsh6DCDnMN1KW2g4QKkqKmejlImgWY67dDFPX/x9Kh/op/GK522DchQXEvDi/wD48HKW49XOQ==",
+      "dev": true,
       "requires": {
         "array-back": "^2.0.0",
         "test-value": "^3.0.0"
@@ -1694,12 +1709,14 @@
     "fs-then-native": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fs-then-native/-/fs-then-native-2.0.0.tgz",
-      "integrity": "sha1-GaEk2U2QwiyOBF8ujdbr6jbUjGc="
+      "integrity": "sha1-GaEk2U2QwiyOBF8ujdbr6jbUjGc=",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -1778,7 +1795,8 @@
     "graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "dev": true
     },
     "growl": {
       "version": "1.10.5",
@@ -1790,6 +1808,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
       "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
+      "dev": true,
       "requires": {
         "async": "^2.5.0",
         "optimist": "^0.6.1",
@@ -1800,7 +1819,8 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -1941,6 +1961,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -2240,6 +2261,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
       "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
+      "dev": true,
       "requires": {
         "xmlcreate": "^1.0.1"
       }
@@ -2248,6 +2270,7 @@
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
       "integrity": "sha512-6PxB65TAU4WO0Wzyr/4/YhlGovXl0EVYfpKbpSroSj0qBxT4/xod/l40Opkm38dRHRdQgdeY836M0uVnJQG7kg==",
+      "dev": true,
       "requires": {
         "babylon": "7.0.0-beta.19",
         "bluebird": "~3.5.0",
@@ -2267,6 +2290,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-4.0.3.tgz",
       "integrity": "sha512-dfYq9JgB+XahY0XfSEw93PmXmocjwYcvJ5aMuQUJ/OdDRGWamf2SSOk3W06Bsj8qdjp/UdefzqpP/mpwsvHuvA==",
+      "dev": true,
       "requires": {
         "array-back": "^2.0.0",
         "cache-point": "^0.4.1",
@@ -2283,6 +2307,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-3.0.1.tgz",
       "integrity": "sha512-btZLp4wYl90vcAfgk4hoGQbO17iBVrhh3LJRMKZNtZgniO3F8H2CjxXld0owBIB1XxN+j3bAcWZnZKMnSj3iMA==",
+      "dev": true,
       "requires": {
         "array-back": "^2.0.0",
         "lodash.omit": "^4.5.0",
@@ -2296,6 +2321,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-4.0.1.tgz",
       "integrity": "sha512-LHJRoLoLyDdxNcColgkLoB/rFG5iRP+PNJjMILI0x+95IdEAtyjSt0wJ6ZlKxRpkhBYtQXTQQ119hMqPIUZzTQ==",
+      "dev": true,
       "requires": {
         "array-back": "^2.0.0",
         "command-line-tool": "^0.8.0",
@@ -2340,6 +2366,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
       "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.9"
       }
@@ -2477,12 +2504,14 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
     },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -2499,17 +2528,20 @@
     "lodash.omit": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
+      "dev": true
     },
     "lodash.padend": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
+      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
+      "dev": true
     },
     "lodash.pick": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+      "dev": true
     },
     "lodash.snakecase": {
       "version": "4.1.1",
@@ -2565,7 +2597,8 @@
     "marked": {
       "version": "0.3.19",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -2639,6 +2672,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -2646,7 +2680,8 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -2673,6 +2708,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -2680,7 +2716,8 @@
     "mkdirp2": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.4.tgz",
-      "integrity": "sha512-Q2PKB4ZR4UPtjLl76JfzlgSCUZhSV1AXQgAZa1qt5RiaALFjP/CDrGvFBrOz7Ck6McPcwMAxTsJvWOUjOU8XMw=="
+      "integrity": "sha512-Q2PKB4ZR4UPtjLl76JfzlgSCUZhSV1AXQgAZa1qt5RiaALFjP/CDrGvFBrOz7Ck6McPcwMAxTsJvWOUjOU8XMw==",
+      "dev": true
     },
     "mocha": {
       "version": "6.0.1",
@@ -4042,7 +4079,8 @@
     "object-get": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz",
-      "integrity": "sha1-ciu9tgA576R8rTxtws5RqFwCxa4="
+      "integrity": "sha1-ciu9tgA576R8rTxtws5RqFwCxa4=",
+      "dev": true
     },
     "object-keys": {
       "version": "1.1.0",
@@ -4053,7 +4091,8 @@
     "object-to-spawn-args": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-1.1.1.tgz",
-      "integrity": "sha1-d9qIJ/Bz0BHJ4bFz+JV4FHAkZ4U="
+      "integrity": "sha1-d9qIJ/Bz0BHJ4bFz+JV4FHAkZ4U=",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -4108,6 +4147,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -4131,6 +4171,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -4139,7 +4180,8 @@
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
         }
       }
     },
@@ -4261,7 +4303,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -4413,6 +4456,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
       "integrity": "sha1-Z/I4W+2mUGG19fQxJmLosIDKFSU=",
+      "dev": true,
       "requires": {
         "test-value": "^1.0.1"
       },
@@ -4421,6 +4465,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
           "requires": {
             "typical": "^2.6.0"
           }
@@ -4429,6 +4474,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
           "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
+          "dev": true,
           "requires": {
             "array-back": "^1.0.2",
             "typical": "^2.4.2"
@@ -4439,17 +4485,20 @@
     "reduce-flatten": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
-      "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc="
+      "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
+      "dev": true
     },
     "reduce-unique": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/reduce-unique/-/reduce-unique-1.0.0.tgz",
-      "integrity": "sha1-flhrz4ek4ytter2Cd/rWzeyfSAM="
+      "integrity": "sha1-flhrz4ek4ytter2Cd/rWzeyfSAM=",
+      "dev": true
     },
     "reduce-without": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
       "integrity": "sha1-aK0OrRGFXJo31OglbBW7+Hly/Iw=",
+      "dev": true,
       "requires": {
         "test-value": "^2.0.0"
       },
@@ -4458,6 +4507,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
           "requires": {
             "typical": "^2.6.0"
           }
@@ -4466,6 +4516,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
           "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
+          "dev": true,
           "requires": {
             "array-back": "^1.0.3",
             "typical": "^2.6.0"
@@ -4539,6 +4590,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
       "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
+      "dev": true,
       "requires": {
         "underscore": "~1.6.0"
       },
@@ -4546,7 +4598,8 @@
         "underscore": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+          "dev": true
         }
       }
     },
@@ -4897,6 +4950,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-2.0.0.tgz",
       "integrity": "sha1-OKnG2if9fRR7QuYFVPKBGHtN9HI=",
+      "dev": true,
       "requires": {
         "array-back": "^1.0.4",
         "object-get": "^2.1.0",
@@ -4907,6 +4961,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
           "requires": {
             "typical": "^2.6.0"
           }
@@ -5021,6 +5076,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
       "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
+      "dev": true,
       "requires": {
         "array-back": "^1.0.2"
       },
@@ -5029,6 +5085,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
           "requires": {
             "typical": "^2.6.0"
           }
@@ -5038,7 +5095,8 @@
     "stream-via": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
-      "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ=="
+      "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
+      "dev": true
     },
     "string-width": {
       "version": "2.1.1",
@@ -5083,7 +5141,8 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
     },
     "superagent": {
       "version": "3.8.3",
@@ -5177,6 +5236,7 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.4.tgz",
       "integrity": "sha512-uNaR3SRMJwfdp9OUr36eyEi6LLsbcTqTO/hfTsNviKsNeyMBPICJCC7QXRF3+07bAP6FRwA8rczJPBqXDc0CkQ==",
+      "dev": true,
       "requires": {
         "array-back": "^2.0.0",
         "deep-extend": "~0.6.0",
@@ -5188,17 +5248,20 @@
     "taffydb": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg="
+      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
+      "dev": true
     },
     "temp-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
-      "integrity": "sha1-JLFUOXOrRCiW2a02fdnL2/r+kYs="
+      "integrity": "sha1-JLFUOXOrRCiW2a02fdnL2/r+kYs=",
+      "dev": true
     },
     "test-value": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
       "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
+      "dev": true,
       "requires": {
         "array-back": "^2.0.0",
         "typical": "^2.6.1"
@@ -5323,28 +5386,25 @@
     "typical": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
+      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.4.9",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
       "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+      "dev": true,
       "optional": true,
       "requires": {
         "commander": "~2.17.1",
         "source-map": "~0.6.1"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.17.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-          "optional": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
           "optional": true
         }
       }
@@ -5352,12 +5412,14 @@
     "underscore": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+      "dev": true
     },
     "underscore-contrib": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
       "integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
+      "dev": true,
       "requires": {
         "underscore": "1.6.0"
       },
@@ -5365,7 +5427,8 @@
         "underscore": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+          "dev": true
         }
       }
     },
@@ -5501,7 +5564,8 @@
     "walk-back": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-3.0.1.tgz",
-      "integrity": "sha512-umiNB2qLO731Sxbp6cfZ9pwURJzTnftxE4Gc7hq8n/ehkuXC//s9F65IEIJA2ZytQZ1ZOsm/Fju4IWx0bivkUQ=="
+      "integrity": "sha512-umiNB2qLO731Sxbp6cfZ9pwURJzTnftxE4Gc7hq8n/ehkuXC//s9F65IEIJA2ZytQZ1ZOsm/Fju4IWx0bivkUQ==",
+      "dev": true
     },
     "which": {
       "version": "1.3.1",
@@ -5537,6 +5601,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
       "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
+      "dev": true,
       "requires": {
         "reduce-flatten": "^1.0.1",
         "typical": "^2.6.1"
@@ -5592,7 +5657,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write": {
       "version": "1.0.3",
@@ -5606,7 +5672,8 @@
     "xmlcreate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
-      "integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8="
+      "integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
+      "dev": true
     },
     "y18n": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   ],
   "dependencies": {
     "http-errors": "1.7.2",
-    "jsdoc-to-markdown": "4.0.1",
     "koa-compose": "4.1.0",
     "methods": "1.1.2",
     "path-to-regexp": "1.1.1",
@@ -47,6 +46,7 @@
     "eslint-plugin-promise": "4.0.1",
     "eslint-plugin-unicorn": "7.1.0",
     "expect.js": "0.3.1",
+    "jsdoc-to-markdown": "4.0.1",
     "koa": "2.7.0",
     "mocha": "6.0.1",
     "nyc": "13.3.0",


### PR DESCRIPTION
Hey, thanks for creating a maintained version of koa-router!

I'm just fixing a miss-classified dependency.

# Change Type

* [ ] Feature
* [x] Chore
* [ ] Bug Fix

# Change Level

* [ ] major
* [ ] minor
* [x] patch

# Further Information (screenshots, bug report links, etc.)
N/A

# Checklist

* [x] Added tests / did not decrease code coverage
* [x] Tested in supported environments (common browsers or current and LTS Node)
